### PR TITLE
setting jib-maven-plugin to 3.1.1 for Conconcourse build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,7 @@
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
-                <version>3.1.4</version>
+                <version>3.1.1</version>
             </plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
The docker-build job is failing in Concourse.
All our other 'Thundercat' services have the version at 3.1.1
This did the trick in 3pa-web, now doing 3pa-api.